### PR TITLE
Revert "Update README.md - Added cf-mysql release path"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 TITLE: MariaDB Control Script
 ---
 
-This repository contains a go process to manage the start process for MariaDB in [cf-mysql-release] (https://github.com/cloudfoundry/cf-mysql-release).
+This repository contains a go process to manage the start process for MariaDB in cf-mysql-release release (github.com/cloudfoundry/cf-mysql-release).


### PR DESCRIPTION
Reverts cloudfoundry/mariadb_ctrl#1

I'm sorry, I had to revert this. I merged it against master, which was incorrect.

This pull request has been reviewed, and it sounds good. BUT, it's filed against the wrong branch - it should be filed against develop, not master. We've only just published a [CONTRIBUTING](https://github.com/cloudfoundry/cf-riak-cs-release/blob/develop/CONTRIBUTING.md) file, please check it out.

If you could please retract this PR, and re-submit it against develop, I'll be very grateful.

--
  Marco Nicosia
  Product Manager
  Pivotal Software, Inc.
